### PR TITLE
Avoid unnecessary conversions to string and integer it causes rounding errors

### DIFF
--- a/lib/support/xml_mapping/money_node.rb
+++ b/lib/support/xml_mapping/money_node.rb
@@ -8,7 +8,7 @@ class MoneyNode < XML::Mapping::SingleAttributeNode
   end
 
   def extract_attr_value(xml)
-    amount, currency = default_when_xpath_err{ [(@amount_path.first(xml).text.to_f * 100).to_s.to_i,
+    amount, currency = default_when_xpath_err{ [(@amount_path.first(xml).text.to_f * 100),
                                      @currency_path.first(xml).text]
                                   }
     Money.new(amount, currency)


### PR DESCRIPTION
Previously..

``` ruby
(64.99.to_f * 100).to_s.to_i
=> 6498
```

Now returns expected `6499`
