### PR TITLE
Add ProductRequired field to ValidationRules of CategorySpecifics

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,7 +2,7 @@ PATH
   remote: .
   specs:
     ebayapi (0.20.0)
-      activesupport (~> 5.1.5)
+      activesupport (~> 4.2.0)
       libxml-ruby (~> 2.7.0)
       money (~> 6.0)
       rubyjedi-soap4r (~> 2.0.2.1)
@@ -11,15 +11,17 @@ PATH
 GEM
   remote: http://rubygems.org/
   specs:
-    activesupport (5.1.5)
-      concurrent-ruby (~> 1.0, >= 1.0.2)
+    activesupport (4.2.6)
       i18n (~> 0.7)
+      json (~> 1.7, >= 1.7.7)
       minitest (~> 5.1)
+      thread_safe (~> 0.3, >= 0.3.4)
       tzinfo (~> 1.1)
     concurrent-ruby (1.0.5)
     httpclient (2.8.3)
     i18n (0.9.5)
       concurrent-ruby (~> 1.0)
+    json (1.8.6)
     libxml-ruby (2.7.0)
     logger-application (0.0.2)
     minitest (5.11.3)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,42 +2,40 @@ PATH
   remote: .
   specs:
     ebayapi (0.20.0)
-      activesupport (> 3.1.0)
+      activesupport (~> 5.1.5)
       libxml-ruby (~> 2.7.0)
       money (~> 6.0)
       rubyjedi-soap4r (~> 2.0.2.1)
-      xml-mapping (~> 0.9.1)
+      xml-mapping (> 0.9.1)
 
 GEM
   remote: http://rubygems.org/
   specs:
-    activesupport (4.2.6)
+    activesupport (5.1.5)
+      concurrent-ruby (~> 1.0, >= 1.0.2)
       i18n (~> 0.7)
-      json (~> 1.7, >= 1.7.7)
       minitest (~> 5.1)
-      thread_safe (~> 0.3, >= 0.3.4)
       tzinfo (~> 1.1)
-    httpclient (2.8.0)
-    i18n (0.7.0)
-    json (1.8.3)
+    concurrent-ruby (1.0.5)
+    httpclient (2.8.3)
+    i18n (0.9.5)
+      concurrent-ruby (~> 1.0)
     libxml-ruby (2.7.0)
     logger-application (0.0.2)
-    minitest (5.8.4)
-    money (6.7.0)
-      i18n (>= 0.6.4, <= 0.7.0)
-      sixarm_ruby_unaccent (>= 1.1.1, < 2)
+    minitest (5.11.3)
+    money (6.10.1)
+      i18n (>= 0.6.4, < 1.0)
     power_assert (0.2.4)
     rake (10.4.2)
     rubyjedi-soap4r (2.0.2.1)
       httpclient (~> 2.6)
       logger-application (~> 0.0.2)
-    sixarm_ruby_unaccent (1.1.1)
     test-unit (3.1.5)
       power_assert
-    thread_safe (0.3.5)
-    tzinfo (1.2.2)
+    thread_safe (0.3.6)
+    tzinfo (1.2.5)
       thread_safe (~> 0.1)
-    xml-mapping (0.9.1)
+    xml-mapping (0.10.0)
 
 PLATFORMS
   ruby
@@ -49,4 +47,4 @@ DEPENDENCIES
   test-unit (~> 3.1)
 
 BUNDLED WITH
-   1.11.2
+   1.16.1

--- a/ebayapi.gemspec
+++ b/ebayapi.gemspec
@@ -18,8 +18,8 @@ Gem::Specification.new do |s|
   s.rubyforge_project = s.name
   s.required_rubygems_version = ">= 1.3.4"
 
-  s.add_dependency("activesupport", ["> 3.1.0"])
-  s.add_dependency("xml-mapping", ["~> 0.9.1"])
+  s.add_dependency("activesupport", ["~> 5.1.5"])
+  s.add_dependency("xml-mapping", ["> 0.9.1"])
   s.add_dependency("rubyjedi-soap4r", ["~> 2.0.2.1"])
   s.add_dependency("libxml-ruby", ["~> 2.7.0"])
   s.add_dependency("money", ["~> 6.0"])

--- a/ebayapi.gemspec
+++ b/ebayapi.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |s|
   s.rubyforge_project = s.name
   s.required_rubygems_version = ">= 1.3.4"
 
-  s.add_dependency("activesupport", ["~> 5.1.5"])
+  s.add_dependency("activesupport", ["~> 4.2.0"])
   s.add_dependency("xml-mapping", ["> 0.9.1"])
   s.add_dependency("rubyjedi-soap4r", ["~> 2.0.2.1"])
   s.add_dependency("libxml-ruby", ["~> 2.7.0"])

--- a/lib/ebay/types/recommendation_validation_rules.rb
+++ b/lib/ebay/types/recommendation_validation_rules.rb
@@ -12,6 +12,7 @@ module Ebay # :nodoc:
     #  text_node :variation_picture, 'VariationPicture', :optional => true
     #  text_node :variation_specifics, 'VariationSpecifics', :optional => true
     #  text_node :value_format, 'ValueFormat', :optional => true
+    #  text_node :product_required, 'ProductRequired', :optional => true
     class RecommendationValidationRules
       include XML::Mapping
       include Initializer
@@ -25,6 +26,7 @@ module Ebay # :nodoc:
       text_node :variation_picture, 'VariationPicture', :optional => true
       text_node :variation_specifics, 'VariationSpecifics', :optional => true
       text_node :value_format, 'ValueFormat', :optional => true
+      text_node :product_required, 'ProductRequired', :optional => true
     end
   end
 end


### PR DESCRIPTION
We need to request for `CategorySpecifics of Trading API` to determine for which brand of the given category listings required to pass `eBay product id(epid)` in order to create/revise them. CategorySpecifics API responds with `Response.Recommendations.NameRecommendation.ValidationRules.ProductRequired = 'Enabled'` if `epid` is required.

https://developer.ebay.com/devzone/xml/docs/reference/ebay/GetCategorySpecifics.html#Response.Recommendations.NameRecommendation.ValidationRules.ProductRequired