### PR TITLE
Add ProductRequired field to ValidationRules of CategorySpecifics

### DIFF
--- a/lib/ebay/types/recommendation_validation_rules.rb
+++ b/lib/ebay/types/recommendation_validation_rules.rb
@@ -12,6 +12,7 @@ module Ebay # :nodoc:
     #  text_node :variation_picture, 'VariationPicture', :optional => true
     #  text_node :variation_specifics, 'VariationSpecifics', :optional => true
     #  text_node :value_format, 'ValueFormat', :optional => true
+    #  text_node :product_required, 'ProductRequired', :optional => true
     class RecommendationValidationRules
       include XML::Mapping
       include Initializer
@@ -25,6 +26,7 @@ module Ebay # :nodoc:
       text_node :variation_picture, 'VariationPicture', :optional => true
       text_node :variation_specifics, 'VariationSpecifics', :optional => true
       text_node :value_format, 'ValueFormat', :optional => true
+      text_node :product_required, 'ProductRequired', :optional => true
     end
   end
 end


### PR DESCRIPTION
We need to request for `CategorySpecifics of Trading API` to determine for which brand of the given category listings required to pass `eBay product id(epid)` in order to create/revise them. CategorySpecifics API responds with `Response.Recommendations.NameRecommendation.ValidationRules.ProductRequired = 'Enabled'` if `epid` is required.

https://developer.ebay.com/devzone/xml/docs/reference/ebay/GetCategorySpecifics.html#Response.Recommendations.NameRecommendation.ValidationRules.ProductRequired